### PR TITLE
fix(cli): correct positional argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning][semver].
 The format of this changelog is [a variant][lib9-versionning] of [Keep a Changelog][keep-changelog].
 New entries must be placed in a section entitled `Unreleased`.
 
+## Unreleased
+
+### Fixed
+- Correct CLI argument parsing when using `compile` command to properly identify schema files
+
 ## 0.17.0 (2025-05-03)
 
 -   BREAKING CHANGES: require tags in unions and enum to be declared in ascending order.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bare-ts/tools",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Compiler for Binary Application Record Encoding (BARE) schemas",
   "keywords": [
     "bare",

--- a/src/bin/bare.ts
+++ b/src/bin/bare.ts
@@ -83,15 +83,17 @@ function main(): void {
         } else if (values.version) {
             console.info(packageVersion)
         } else {
-            if (positionals.length > 1 && positionals[0] === "compile") {
-                positionals.pop()
+            let schemaIndex = 0
+
+            if (positionals.length > 0 && positionals[0] === "compile") {
+                schemaIndex = 1
             }
-            if (positionals.length > 1) {
-                console.error("only one argument is expected")
+            if (positionals.length > schemaIndex + 1) {
+                console.error("only one schema argument is expected")
                 process.exit(1)
             }
-            const schema = positionals.length > 0 ? positionals[0] : 0
-            const out = values.out ?? 1
+            const schema =
+                positionals.length > schemaIndex ? positionals[schemaIndex] : 0
             const generator = values.generator
             if (
                 generator != null &&
@@ -103,13 +105,12 @@ function main(): void {
                 console.error("Invalid <generator> value")
                 process.exit(1)
             }
-            compileAction(out, {
+            compileAction(schema, {
                 generator,
                 legacy: values.legacy,
                 lib: values.lib,
                 out: values.out,
                 pedantic: values.pedantic,
-                schema,
                 useClass: values["use-class"],
                 useGenericArray: values["use-generic-array"],
                 useIntEnum: values["use-int-enum"],


### PR DESCRIPTION
- Fix handling of 'compile' command in positional arguments
- Ensure schema file is properly identified when using compile command
- Prevent incorrect assignment of output file as schema input
- Maintain backward compatibility with existing command usage

Addresses: https://github.com/bare-ts/bare/issues/2